### PR TITLE
Mainnet Instructions Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.yarn/

--- a/docs/nodes/nodes/2_installation.md
+++ b/docs/nodes/nodes/2_installation.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 There are a few things needed before installing.
 
-::: tip
+:::tip
 
 Perform the follow instructions as `root` or your `admin` account.
 
@@ -105,11 +105,11 @@ sudo systemctl enable canined.service
 ```
 
 ## Building from Source
-::: tip
+:::tip
 
 Perform the next follow steps as your `jackal` user
 
-::
+:::
 
 Replace `<VERSION>` with the current running version.
 ```sh

--- a/docs/nodes/nodes/2_installation.md
+++ b/docs/nodes/nodes/2_installation.md
@@ -7,11 +7,17 @@ sidebar_position: 2
 
 There are a few things needed before installing.
 
-### Installing Build Essentials
+::: tip
+
+Perform the follow instructions as `root` or your `admin` account.
+
+:::
+### Installing required tools
+This will install the necessary tools to build the jackal chain source, along with lz4 compression tool and jquery tool.
 
 ```sh
 sudo apt update
-sudo apt install build-essential
+sudo apt install build-essential lz4 jq
 ```
 
 ### Installing Go
@@ -20,17 +26,24 @@ Follow more in-depth instructions to install Go v1.19 or higher [here](https://g
 On Ububtu you can install it with:
 
 ```sh
-wget https://golang.org/dl/go1.19.3.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.19.3.linux-amd64.tar.gz
+GOVER=$(curl https://go.dev/VERSION?m=text)
+wget https://golang.org/dl/${GOVER}.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf ${GOVER}.linux-amd64.tar.gz
 ```
 
-Add these lines to the end of `~/.profile`:
+Add the following golang path info to the current users `~/.profile`.
+
+Also add it to the skeleton profile so all new users have it. `/etc/skel/.profile`
 
 ```sh
-export GOROOT=/usr/local/go
-export GOPATH=$HOME/go
-export GO111MODULE=on
-export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+# add environmental variables for Go
+if [ -f "/usr/local/go/bin/go" ] ; then
+    export GOROOT=/usr/local/go
+    export GOPATH=${HOME}/go
+    export GOBIN=$GOPATH/bin
+    export PATH=${PATH}:${GOROOT}/bin:${GOBIN}
+    export GO111MODULE=on
+fi
 ```
 
 Restarting the shell with youre profile settings or just rebasing them like so is required.
@@ -39,12 +52,70 @@ Restarting the shell with youre profile settings or just rebasing them like so i
 source ~/.profile
 ```
 
-## Building from Source
+### Firewall Configuration
+Configure UFW to only accept traffic on ports we use.
 
+```bash
+ufw limit ssh/tcp comment 'Rate limit for openssh server'
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 26656/tcp comment 'JACKAL - Cosmos SDK/Tendermint P2P'
+ufw enable
+```
+
+### Create Jackal user
+
+```sh
+sudo adduser --gecos "" jackal
+```
+
+### Creating a Service
+You may want the daemon to run without you needing to supervise it. To turn the executable into a service follow these steps.
+
+First create the service file `/etc/systemd/system/jackal.service`
+
+```sh
+sudo nano /etc/systemd/system/jackal.service
+```
+
+Copy and paste the follow into the service file: (you may need to edit it if you've set a custom home directory location)
+
+```conf
+[Unit]
+Description=Jackal Validator
+After=network.target
+
+[Service]
+Group=jackal
+User=jackal
+WorkingDirectory=/home/jackal
+ExecStart=/home/jackal/go/bin/canined start
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=8192
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Update systemd and enable the service file.
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable canined.service
+```
+
+## Building from Source
+::: tip
+
+Perform the next follow steps as your `jackal` user
+
+::
+
+Replace `<VERSION>` with the current running version.
 ```sh
 git clone https://github.com/JackalLabs/canine-chain.git
 cd canine-chain
-git fetch
+git fetch -a
 git checkout <VERSION>
 
 make install
@@ -53,54 +124,4 @@ make install
 From there you will be able to use `canined`, ex:
 ```sh
 canined version
-```
-
-## Syncing to Current Height
-
-Get a snapshot [here](http://snapshots.autostake.net/jackal-1/).
-
-For the sake of this guide, the snapshot we download is named `jackal.tar.lz4`
-
-```sh
-sudo snap install lz4
-canined unsafe-reset-all --keep-addr-book
-lz4 -c -d jackal.tar.lz4  | tar -x -C $HOME/.canine
-```
-
-Then start the chain again.
-
-### Versions for Sync
-
-| block height | canined version |
-|--------------|-----------------|
-| 45381        | 1.1.2           |
-| 0            | 1.1.0           |
-
-## Creating a Service
-You may want the daemon to run without you needing to supervise it. To turn the executable into a service follow these steps.
-
-```sh
-cd $HOME
-echo "[Unit]
-Description=Jackal Node
-After=network-online.target
-[Service]
-User=${USER}
-ExecStart=$(which canined) start
-Restart=always
-RestartSec=3
-LimitNOFILE=4096
-[Install]
-WantedBy=multi-user.target
-" > canined.service
-
-sudo mv canined.service /lib/systemd/system/
-sudo systemctl enable canined.service
-
-# Starting the service
-sudo systemctl start canined.service
-
-# Restarting the service
-sudo systemctl daemon-reload
-sudo systemctl restart canined.service
 ```

--- a/docs/nodes/nodes/4_mainnet.md
+++ b/docs/nodes/nodes/4_mainnet.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 ---
 # Joining Mainnet
 
-::: tip
+:::tip
 
 Perform the following as the `jackal` user.
 

--- a/docs/nodes/nodes/4_mainnet.md
+++ b/docs/nodes/nodes/4_mainnet.md
@@ -3,23 +3,17 @@ sidebar_position: 4
 ---
 # Joining Mainnet
 
-:::info
+::: tip
 
-Mainnet goes live on October 26th 2022! If you are here before that, these docs will not work!
+Perform the following as the `jackal` user.
 
 :::
 
 After installing `canined`. You can join the mainnet by following these steps:
 
 ```sh
-canined init <alias> --chain-id=<chain-id>
+canined init "NODE_NAME" --chain-id=jackal-1
 ```
-
-:::note
-
-`chain-id` for mainnet is currently `jackal-1`.
-
-:::
 
 Then we want to replace our generated genesis file with the one used to start the network.
 
@@ -32,3 +26,123 @@ GAS="0.002ujkl"
 
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/; s/^persistent_peers *=.*/persistent_peers = \"$PEERS\"/" $HOME/.canine/config/config.toml
 ```
+## Backing up key files
+
+The created `node_key.json` and `priv_validator_key.json` cannot be recovered.  These files ***must*** be backed up.
+
+```sh
+mkdir ~/key_backup
+cp ~/.canine/config/node_key.json ~/key_backup
+cp ~/.canine/config/priv_validator_key.json ~/key_backup
+```
+
+You should also keep an offline backup.  Using a program like `WinSCP`, you can easily copy these files to your personal desktop for safe storage/backup.
+
+## Syncing to Current Height
+
+### Snapshot method
+Get a snapshot [here](http://snapshots.autostake.net/jackal-1/).
+
+For the sake of this guide, the snapshot we download is named `jackal.tar.lz4`
+
+If you plan on becoming a validator, before using the `unsafe-reset-all` flag, always besure to back up your `priv_validator_state.json` file.  
+
+```sh
+canined unsafe-reset-all --keep-addr-book
+lz4 -c -d jackal.tar.lz4  | tar -x -C $HOME/.canine
+```
+
+Then start the chain again.
+
+### State Sync Method
+There are a couple of ways to go about doing state sync.
+First is the easier route.  Visit [Ping.pub](https://ping.pub/jackal/statesync) for Jackals State Sync configuration settings.
+
+Next, copy these settings from Ping.pub to your `config.toml` in the `[statesync]` section.
+
+It should look similar to this:
+
+```sh
+#######################################################
+###         State Sync Configuration Options        ###
+#######################################################
+[statesync]
+# State sync rapidly bootstraps a new node by discovering, fetching, and restoring a state machine
+# snapshot from peers instead of fetching and replaying historical blocks. Requires some peers in
+# the network to take and serve state machine snapshots. State sync is not attempted if the node
+# has any local state (LastBlockHeight > 0). The node will have a truncated block history,
+# starting from the height of the snapshot.
+enable = true
+
+# RPC servers (comma-separated) for light client verification of the synced state machine and
+# retrieval of state data for node bootstrapping. Also needs a trusted height and corresponding
+# header hash obtained from a trusted source, and a period during which validators can be trusted.
+#
+# For Cosmos SDK-based chains, trust_period should usually be about 2/3 of the unbonding time (~2
+# weeks) during which they can be financially punished (slashed) for misbehavior.
+rpc_servers = "https://rpc.jackalprotocol.com:443,https://rpc.jackalprotocol.com:443"
+trust_height = 333000
+trust_hash = "1685850c2d115a86af9059bd3f36a4fbbb0e8ba7f37863d517b6d2f54116daca"
+trust_period = "168h"  # 2/3 of unbonding time
+
+# Time to spend discovering snapshots before initiating a restore.
+discovery_time = "15s"
+
+# Temporary directory for state sync snapshot chunks, defaults to the OS tempdir (typically /tmp).
+# Will create a new, randomly named directory within, and remove it when done.
+temp_dir = ""
+
+# The timeout duration before re-requesting a chunk, possibly from a different
+# peer (default: 1 minute).
+chunk_request_timeout = "10s"
+
+# The number of concurrent chunk fetchers to run (default: 1).
+chunk_fetchers = "42"
+```
+
+State syncing can take up to a few minutes to complete.  Watch the logs to ensure it's happening.  When a snapshot is found, you will see output in your log that is similar to this:
+
+```sh
+1PM INF Discovered new snapshot format=1 hash="S.�h�F���\"\x1d6+\x1e���ޅ��`v@�ц�����" height=1810000 module=statesync
+```
+
+It will download, verify, and apply chuncks of blockchain data.  When it finishes you will see it catching up to blocks
+
+### State Sync Method 2
+
+The follow commandline code will edit your `config.toml` with the proper information for state syncing to the most recent snapshot 3000 blocks and beyond.
+
+```sh
+STATE_SYNC_RPC=https://rpc.jackalprotocol.com:443
+LATEST_HEIGHT=$(curl -s $STATE_SYNC_RPC/block | jq -r .result.block.header.height)
+SYNC_BLOCK_HEIGHT=$(($LATEST_HEIGHT - 3000))
+SYNC_BLOCK_HASH=$(curl -s "$STATE_SYNC_RPC/block?height=$SYNC_BLOCK_HEIGHT" | jq -r .result.block_id.hash)
+
+sed -i.bak -e "s|^enable *=.*|enable = true|" $HOME/.teritorid/config/config.toml
+sed -i.bak -e "s|^rpc_servers *=.*|rpc_servers = \"$STATE_SYNC_RPC,$STATE_SYNC_RPC\"|" \
+  $HOME/.teritorid/config/config.toml
+sed -i.bak -e "s|^trust_height *=.*|trust_height = $SYNC_BLOCK_HEIGHT|" \
+  $HOME/.teritorid/config/config.toml
+sed -i.bak -e "s|^trust_hash *=.*|trust_hash = \"$SYNC_BLOCK_HASH\"|" \
+  $HOME/.teritorid/config/config.toml
+```
+
+When you state sync, you can start with the latest version of `canined`.
+
+### Versions for Sync
+
+| block height | canined version |
+|--------------|-----------------|
+| 45381        | 1.1.2           |
+| 0            | 1.1.0           |
+
+## Starting the daemon
+
+Start the daemon and sync to the current height.
+
+```sh
+sudo systemctl start jackal
+sudo journalctl -u jackal -f
+```
+
+Watch the logs and ensure you are either state syncing correctly, or are syncing up to the current height.

--- a/docs/nodes/validators/1_joining.md
+++ b/docs/nodes/validators/1_joining.md
@@ -4,27 +4,79 @@ sidebar_position: 1
 # Creating Validator
 
 
-## Disclaimer
+::: tip
 
 This guide assumes you are using the same machine as the full node.
 
+Perform the following steps as your `jackal` user.
+
+:::
+
+## Creating A Wallet
+
+We need to create a wallet and set the keyring password.
+
+```sh
+canined keys add WALLET_NAME --keyring-backend os
+```
+
+This wallet is used to claim rewards, commission and to vote as your validator.
+
+You will see a similar output once created.
+
+```
+- name: WALLET_NAME
+  type: local
+  address: jkl1hjhglrzggqtdhsh3ag8jp0cckmva5pe976jxel
+  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Rnrlv1TNrt1cz3+pSq2UDNiJQZINNlgtkNousVlkugZ7"}'
+  mnemonic: ""
+
+
+**Important** write this mnemonic phrase in a safe place.
+It is the only way to recover your account if you ever forget your password.
+
+some words forming mnemonic seed will be placed here you have to write them down and keep them safe
+```
+
+Besure to back up the seed phrase of your validator wallet.  It's also recommened to keep an offline copy along with your key files.  Remember, your key files cannot be restored and ***must*** be backed up.  See the installation page for instructions.
+
+You should also backup your keyring files.
+
+Change `WALLET_NAME` to the name of your wallet.
+```sh
+mkdir ~/keyring_backup
+cp ~/.canine/WALLET_NAME.info ~/keyring_backup
+cp ~/.canine/keyhash ~/keyring_backup
+```
+
 ## Setting Up
+
+### Configure Gas Prices
 
 As a validator, you'll need to set a minimum gas price like so:
 ```sh
-GAS="0.002ujkl"
+GAS="0.02ujkl"
 sed -i.bak -e "s/^minimum-gas-prices *=.*/minimum-gas-prices = \"$GAS\"/" $HOME/.canine/config/app.toml
 ```
 
+### Create Your Validator
+
+Before continuing, please note that `commission-max-change` and `commission-max-rate` cannot be changed once you set them.  Your `commission-rate` may be changed once per day.
+
+There are a few things you will need to alter in this command.  `amount` needs to be changed to what you are starting your self bond as.  `from` needs to be the name of your wallet you created earlier.  The `moniker`, `details`, `identity`, `website`, and `security-contact` should all be filled with the appropiate information.
 ```sh
 canined tx staking create-validator \
     --amount 1000000ujkl \
     --commission-max-change-rate 0.10 \
     --commission-max-rate 0.2 \
     --commission-rate 0.1 \
-    --from {WALLET_NAME} \
+    --from WALLET_NAME \
     --min-self-delegation 1 \
-    --moniker {YOUR_MONIKER} \
+    --moniker "YOUR_MONIKER" \
+    --details="YOUR DETAILS" \
+    --identity "PGP IDENTITY" \
+    --website="https://example.com" \
+    --security-contact="your-email@email.com" \
     --pubkey $(canined tendermint show-validator) \
     --chain-id jackal-1 \
     --gas-prices 0.02ujkl

--- a/docs/nodes/validators/1_joining.md
+++ b/docs/nodes/validators/1_joining.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 # Creating Validator
 
 
-::: tip
+:::tip
 
 This guide assumes you are using the same machine as the full node.
 


### PR DESCRIPTION
Hello.  I've been in contact with Szuriel on discord, and we were able to successfully set up the official API/RPC node to offer state sync.  I've tested it out and was able to quickly sync a new node to the current height.

I made a few organizing changes as well as the addition of some new instructions.

I moved the snapshot instructions to be in the joining mainnet section.  The snapshot offered is a mainnet only snapshot, so it seemed more fitting to be there.  This is also where I added the State Sync instructions.

I added instructions for users to create a jackal user for the use of the daemon.  I changed the already included instructions to fit this change.

I added extra steps for creating a validator.  One was creating a wallet.  Also some tips/instructions on backing up certain files that are irreplaceable. 

I would recommend we set up the testnet API/RPC to offer state sync as well.  If that is something you and the team wants, let me know and then we can go through, set it up and change the documentation to fit that need.

I have setup a dev environment and am hosting the changes live for you to see beforehand.  http://erialosofastora.asuscomm.com:8080/docs/nodes/nodes/installation

