### PR TITLE
update provider docs

### DIFF
--- a/docs/nodes/1_install.md
+++ b/docs/nodes/1_install.md
@@ -5,19 +5,18 @@ sidebar_position: 0
 
 ## Pre-Requisites 
 
-There are a few things needed before installing.
+There are a few things needed before installing. 
 
-:::tip
-
-Perform the follow instructions as `root` or your `admin` account.
-
-:::
+While logged in as the 'root' or 'admin' user, we add a 'jackal' user and give them root privileges.
 
 ### Create Jackal user
 
 ```sh
 sudo adduser --gecos "" jackal
+sudo usermod -aG sudo jackal
 ```
+
+Re-log in as the jackal user to complete the below steps. 
 
 ### Installing required tools
 This will install the necessary tools to build the jackal chain source, along with lz4 compression tool and jquery tool.

--- a/docs/nodes/providers/1_building.md
+++ b/docs/nodes/providers/1_building.md
@@ -44,10 +44,16 @@ Disk identifier: D2827F71-7F0A-EE4A-BB12-1B2172641DBE
 ...
 ```
 
-Note down the Disk paths that you wish to use for your storage provider, in this case it is `/dev/sdb` and `/dev/sda`. Now we create a new pool as follows:
+Note down the Disk paths that you wish to use for your storage provider, in this case it is `/dev/sdb` and `/dev/sda`. 
+
+We install ZFS and create a new pool as follows:
 
 ```sh
-sudo zpool create {pool-name} /dev/sdb /dev/sda ...
+sudo apt install zfsutils-linux
+
+sudo zpool create {pool-name} /dev/sda /dev/sdb ...
+
+sudo zpool status
 ```
 
 This folder will now have the drives mounted at `/{pool-name}`. For more in-depth guides to using zfs, check out [this page](https://zfsonlinux.org/).

--- a/docs/nodes/providers/2_setting_up.md
+++ b/docs/nodes/providers/2_setting_up.md
@@ -20,17 +20,6 @@ Check latest version [here](https://github.com/JackalLabs/canine-provider/releas
 
 :::
 
-Install make and confirm installation. 
-
-```sh
-sudo apt update
-
-sudo apt install make
-
-make --version
-
-```
-
 Build jprovd and source the .profile to ensure your shell can find jprovd. Confirm installation. 
 
 ```sh
@@ -42,9 +31,9 @@ git pull
 
 git checkout {version}
 
-make install
-
 source ~/.profile
+
+make install
 
 jprovd --version 
 
@@ -112,7 +101,7 @@ Mainnet tokens can be purchased on https://frontier.osmosis.zone/
 5. Initialize the provider 
 
 ```sh
-jprovd init {IP_ADDRESS} {STORAGE_IN_BYTES} {KEYBASE_IDENTITY} --home=$PHOME
+jprovd init {FQDN} {STORAGE_IN_BYTES} {KEYBASE_IDENTITY} --home=$PHOME
 ```
 
 example:
@@ -121,7 +110,7 @@ example:
 jprovd init "https://storagep1.chainstrategies.cloud" "9000" "" --home=$PHOME
 ```
 
- Please note that 'https://' is required to be included in the ip or init will throw an error. 
+ Please note that 'https://' is required to be included in the FQDN or init will throw an error. 
  Link for TB to Bytes converter: https://www.convertunits.com/from/TB/to/byte 
 
 6. Start the provider 

--- a/docs/nodes/providers/2_setting_up.md
+++ b/docs/nodes/providers/2_setting_up.md
@@ -20,6 +20,17 @@ Check latest version [here](https://github.com/JackalLabs/canine-provider/releas
 
 :::
 
+Install make and confirm installation. 
+
+```sh
+sudo apt update
+
+sudo apt install make
+
+make --version
+
+```
+
 Build jprovd and source the .profile to ensure your shell can find jprovd. Confirm installation. 
 
 ```sh
@@ -31,9 +42,9 @@ git pull
 
 git checkout {version}
 
-source ~/.profile
-
 make install
+
+source ~/.profile
 
 jprovd --version 
 

--- a/docs/nodes/providers/2_setting_up.md
+++ b/docs/nodes/providers/2_setting_up.md
@@ -50,7 +50,7 @@ jprovd --version
 
 ```
 
-If you used ZFS to make a zpool. Given ownership of the zpool to the jackal user. 
+If you used ZFS to make a zpool. Give ownership of the zpool to the jackal user. 
 
 ```sh
 

--- a/docs/nodes/providers/2_setting_up.md
+++ b/docs/nodes/providers/2_setting_up.md
@@ -16,9 +16,22 @@ Check latest version [here](https://github.com/JackalLabs/canine-provider/releas
 
 :::note
 
-'Setting Up' instructions must be followed fully to add necessary golang path info to the current users ~/.profile. If these steps are skipped, 'make install' will not build jprovd--the provider daemon. 
+'Setting Up' instructions must be followed fully to add necessary golang path info to the current users ~/.profile. If these steps are skipped, 'make install' will not build jprovd--the provider daemon. Please ensure to perform the below steps as the 'jackal' user you previously made. 
 
 :::
+
+Install make and confirm installation. 
+
+```sh
+sudo apt update
+
+sudo apt install make
+
+make --version
+
+```
+
+Build jprovd and source the .profile to ensure your shell can find jprovd. Confirm installation. 
 
 ```sh
 git clone https://github.com/JackalLabs/canine-provider.git
@@ -30,6 +43,19 @@ git pull
 git checkout {version}
 
 make install
+
+source ~/.profile
+
+jprovd --version 
+
+```
+
+If you used ZFS to make a zpool. Given ownership of the zpool to the jackal user. 
+
+```sh
+
+sudo chown -R jackal:jackal /{pool-name}
+
 ```
 
 ## Initializing


### PR DESCRIPTION
The following commits were made after following the docs through 2 installations with ZFS. 

We failed to make it clear that the jackal user should be created with sudo privileges at the beginning, and then all steps should be completed as the jackal user. This includes giving ownership of the zpool to the jackal user--a critical step. 

Other additions are for quality of life.  