### PR TITLE
Clean up provider install

### DIFF
--- a/docs/nodes/providers/2_setting_up.md
+++ b/docs/nodes/providers/2_setting_up.md
@@ -20,17 +20,6 @@ Check latest version [here](https://github.com/JackalLabs/canine-provider/releas
 
 :::
 
-Install make and confirm installation. 
-
-```sh
-sudo apt update
-
-sudo apt install make
-
-make --version
-
-```
-
 Build jprovd and source the .profile to ensure your shell can find jprovd. Confirm installation. 
 
 ```sh
@@ -42,9 +31,9 @@ git pull
 
 git checkout {version}
 
-make install
-
 source ~/.profile
+
+make install
 
 jprovd --version 
 
@@ -112,7 +101,7 @@ Mainnet tokens can be purchased on https://frontier.osmosis.zone/
 5. Initialize the provider 
 
 ```sh
-jprovd init {IP_ADDRESS} {STORAGE_IN_BYTES} {KEYBASE_IDENTITY} --home=$PHOME
+jprovd init {FQDN} {STORAGE_IN_BYTES} {KEYBASE_IDENTITY} --home=$PHOME
 ```
 
 example:
@@ -121,7 +110,7 @@ example:
 jprovd init "https://storagep1.chainstrategies.cloud" "9000" "" --home=$PHOME
 ```
 
- Please note that 'https://' is required to be included in the ip or init will throw an error. 
+ Please note that 'https://' is required to be included in the FQDN or init will throw an error. 
  Link for TB to Bytes converter: https://www.convertunits.com/from/TB/to/byte 
 
 6. Start the provider 

--- a/docs/nodes/providers/2_setting_up.md
+++ b/docs/nodes/providers/2_setting_up.md
@@ -20,6 +20,17 @@ Check latest version [here](https://github.com/JackalLabs/canine-provider/releas
 
 :::
 
+Install make and confirm installation. 
+
+```sh
+sudo apt update
+
+sudo apt install make
+
+make --version
+
+```
+
 Build jprovd and source the .profile to ensure your shell can find jprovd. Confirm installation. 
 
 ```sh
@@ -31,9 +42,9 @@ git pull
 
 git checkout {version}
 
-source ~/.profile
-
 make install
+
+source ~/.profile
 
 jprovd --version 
 


### PR DESCRIPTION
update to provider IP_ADDRESS to make clear a FQDN should appear there instead.

move source ~/.profile above make install

remove "install make" as this is done when Go is installed