### PR TITLE
fix `jprovd version`

### DIFF
--- a/docs/nodes/providers/2_setting_up.md
+++ b/docs/nodes/providers/2_setting_up.md
@@ -46,7 +46,7 @@ make install
 
 source ~/.profile
 
-jprovd --version 
+jprovd version
 
 ```
 


### PR DESCRIPTION
I noticed a small typo while following provider docs, `jprovd --version` should be `jprov version`